### PR TITLE
feat: add support for multiple network interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
  "presser",
  "thiserror",
  "winapi",
- "windows",
+ "windows 0.51.1",
 ]
 
 [[package]]
@@ -839,7 +839,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -949,9 +949,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
@@ -1743,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.11"
+version = "0.30.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
+checksum = "732ffa00f53e6b2af46208fba5718d9662a421049204e156328b66791ffa15ae"
 dependencies = [
  "cfg-if",
  "core-foundation-sys 0.8.6",
@@ -1753,7 +1753,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "winapi",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -2276,8 +2276,18 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
 dependencies = [
- "windows-core",
+ "windows-core 0.51.1",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -2287,6 +2297,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ clap = "4.4.12"
 crossterm = "0.27.0"
 os_info = "3.7.0"
 serde_json = "1.0.108"
-sysinfo = "0.29.11"
+sysinfo = "0.30.11"
 whoami = "1.4.1"
 winit = "0.29.4"
 serde = { version = "1.0.193", features = ["derive"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,12 +3,13 @@ use clap::error::{ErrorKind};
 use crate::{config, run};
 use crate::model::Rgb;
 
+const FETCHY_VERSION: Option<&str> = option_env!("CARGO_PKG_VERSION");
 // TODO: improve argument parsing
 
 pub fn parse() {
     let command = Command::new("fetchy")
         .author("GHaxZ")
-        .version("0.1.4")
+        .version(FETCHY_VERSION.unwrap_or("dev"))
         .about("A small command line system information tool")
         .arg(Arg::new("color")
             .short('c')

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,14 +1,17 @@
-use std::fmt::{Display, Formatter};
-use battery::State;
+use crate::{config, helper};
 use battery::units::time::second;
+use battery::State;
 use crossterm::style::Stylize;
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
 use wgpu::DeviceType;
-use crate::{config, helper};
+
+const FIRST_SYMBOL: &str = "└─";
+const OTHER_SYMBOL: &str = "├─";
 
 pub struct Dimension {
     pub width: i32,
-    pub height: i32
+    pub height: i32,
 }
 
 pub struct Gpu {
@@ -20,27 +23,27 @@ pub struct Gpu {
 pub struct Drive {
     pub drive_path: String,
     pub storage_total: u64,
-    pub storage_used: u64
+    pub storage_used: u64,
 }
 
 pub struct Network {
     pub network_name: String,
     pub network_up: u64,
-    pub network_down: u64
+    pub network_down: u64,
 }
 
 pub struct Battery {
     pub current_load: u64,
     pub max_load: u64,
     pub current_state: State,
-    pub until_empty_or_full: Option<battery::units::Time>
+    pub until_empty_or_full: Option<battery::units::Time>,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct Rgb {
     pub r: u8,
     pub g: u8,
-    pub b: u8
+    pub b: u8,
 }
 
 pub struct SystemInfo {
@@ -53,7 +56,7 @@ pub struct SystemInfo {
     pub os_bits: String,
     pub host: String,
     pub uptime: String,
-    pub network: Network,
+    pub networks: Vec<Network>,
     pub screen_res: Dimension,
     pub batteries: Option<Vec<Battery>>,
     pub cpu_name: String,
@@ -74,55 +77,81 @@ impl Display for SystemInfo {
 
         let mut str = String::new();
 
-        str.push_str(format!("{}{}{} | {}",
-                         self.user.as_str().with(color).bold(),
-                         "@".bold(),
-                         self.current_path.as_str().with(color).bold(),
-                         self.time.as_str()
-        ).as_str());
+        str.push_str(
+            format!(
+                "{}{}{} | {}",
+                self.user.as_str().with(color).bold(),
+                "@".bold(),
+                self.current_path.as_str().with(color).bold(),
+                self.time.as_str()
+            )
+            .as_str(),
+        );
 
-        str.push_str(format!("\n{}", "─".repeat(self.user.len() + self.current_path.len() + self.time.len() + 4)).as_str());
+        str.push_str(
+            format!(
+                "\n{}",
+                "─".repeat(self.user.len() + self.current_path.len() + self.time.len() + 4)
+            )
+            .as_str(),
+        );
 
-        str.push_str(format!("\n{}: {} {} {}",
-                             "OS".with(color).bold(),
-                             self.os,
-                             self.os_version,
-                             self.os_bits
-        ).as_str());
+        str.push_str(
+            format!(
+                "\n{}: {} {} {}",
+                "OS".with(color).bold(),
+                self.os,
+                self.os_version,
+                self.os_bits
+            )
+            .as_str(),
+        );
 
-        str.push_str(format!("\n{}: {}",
-                             "Host".with(color).bold(),
-                             self.host
-        ).as_str());
+        str.push_str(format!("\n{}: {}", "Host".with(color).bold(), self.host).as_str());
 
-        str.push_str(format!("\n{}: {}",
-                             "Uptime".with(color).bold(),
-                             self.uptime
-        ).as_str());
+        str.push_str(format!("\n{}: {}", "Uptime".with(color).bold(), self.uptime).as_str());
 
-        str.push_str(format!("\n{}: {}",
-                             "Network".with(color).bold(),
-                             self.network.network_name
-        ).as_str());
+        for i in 0..self.networks.len() {
+            if let Some(network) = self.networks.get(i) {
+                str.push_str(
+                    format!(
+                        "\n{}: {}",
+                        "Network".with(color).bold(),
+                        network.network_name
+                    )
+                    .as_str(),
+                );
 
-        str.push_str(format!("\n{}: {}MB ↑ {}MB ↓",
-                             "└ Total usage".with(color).bold(),
-                             self.network.network_up / 1_000_100,
-                             self.network.network_down / 1_000_000
-        ).as_str());
+                str.push_str(
+                    format!(
+                        "\n{}: {}MB ↑ {}MB ↓",
+                        "└─ Total usage".with(color).bold(),
+                        network.network_up / 1_000_100,
+                        network.network_down / 1_000_000
+                    )
+                    .as_str(),
+                );
+            }
+        }
 
-        str.push_str(format!("\n{}: {}x{}",
-                             "Resolution".with(color).bold(),
-                             self.screen_res.width,
-                             self.screen_res.height
-        ).as_str());
+        str.push_str(
+            format!(
+                "\n{}: {}x{}",
+                "Resolution".with(color).bold(),
+                self.screen_res.width,
+                self.screen_res.height
+            )
+            .as_str(),
+        );
 
         if let Some(batteries) = &self.batteries {
-            for battery in batteries.iter(){
+            for battery in batteries.iter() {
                 let mut charge_info = String::new();
 
                 if battery.until_empty_or_full.is_some() {
-                    let time = helper::sec_to_h_m_str(battery.until_empty_or_full.unwrap().get::<second>() as i64);
+                    let time = helper::sec_to_h_m_str(
+                        battery.until_empty_or_full.unwrap().get::<second>() as i64,
+                    );
                     if battery.current_state == State::Charging {
                         charge_info.push_str(format!("{} until full", time).as_str());
                     } else if battery.current_state == State::Discharging {
@@ -130,37 +159,54 @@ impl Display for SystemInfo {
                     }
                 }
 
-                str.push_str(format!("\n{}: {}Wh / {}Wh - {:.0}%",
-                                     "Battery".with(color).bold(),
-                                     battery.current_load,
-                                     battery.max_load,
-                                     (battery.current_load as f64 / battery.max_load as f64) * 100.0
-                ).as_str());
+                str.push_str(
+                    format!(
+                        "\n{}: {}Wh / {}Wh - {:.0}%",
+                        "Battery".with(color).bold(),
+                        battery.current_load,
+                        battery.max_load,
+                        (battery.current_load as f64 / battery.max_load as f64) * 100.0
+                    )
+                    .as_str(),
+                );
 
-                str.push_str(format!("\n{}: {:?}{}",
-                                     "└ State".with(color).bold(),
-                                     battery.current_state,
-                                     if !charge_info.is_empty() {format!(", {}", charge_info)} else {"".to_string()}
-                ).as_str());
+                str.push_str(
+                    format!(
+                        "\n{}: {:?}{}",
+                        "└─ State".with(color).bold(),
+                        battery.current_state,
+                        if !charge_info.is_empty() {
+                            format!(", {}", charge_info)
+                        } else {
+                            "".to_string()
+                        }
+                    )
+                    .as_str(),
+                );
             }
         }
 
-        str.push_str(format!("\n{}: {}",
-                             "CPU".with(color).bold(),
-                             self.cpu_name
-        ).as_str());
+        str.push_str(format!("\n{}: {}", "CPU".with(color).bold(), self.cpu_name).as_str());
 
-        str.push_str(format!("\n{}: {}C {}T @ {:.2}GHz",
-                             "├ Details".with(color).bold(),
-                             self.cpu_cores,
-                             self.cpu_threads,
-                             self.cpu_base_frequency as f32 / 1000.0,
-        ).as_str());
+        str.push_str(
+            format!(
+                "\n{}: {}C {}T @ {:.2}GHz",
+                "├─ Details".with(color).bold(),
+                self.cpu_cores,
+                self.cpu_threads,
+                self.cpu_base_frequency as f32 / 1000.0,
+            )
+            .as_str(),
+        );
 
-        str.push_str(format!("\n{}: {:.1}%",
-                             "└ Utilization".with(color).bold(),
-                             self.cpu_utilization
-        ).as_str());
+        str.push_str(
+            format!(
+                "\n{}: {:.1}%",
+                "└─ Utilization".with(color).bold(),
+                self.cpu_utilization
+            )
+            .as_str(),
+        );
 
         for gpu in self.gpus.iter() {
             let mut type_str = String::new();
@@ -171,50 +217,68 @@ impl Display for SystemInfo {
                 type_str.push_str("Integrated GPU");
             }
 
-            str.push_str(format!("\n{}: {} ({})",
-                                 "GPU".with(color).bold(),
-                                 gpu.name,
-                                 type_str
-            ).as_str());
+            str.push_str(
+                format!(
+                    "\n{}: {} ({})",
+                    "GPU".with(color).bold(),
+                    gpu.name,
+                    type_str
+                )
+                .as_str(),
+            );
 
-            str.push_str(format!("\n{}: {}",
-                                 "└ Driver".with(color).bold(),
-                                 gpu.driver
-            ).as_str());
+            str.push_str(format!("\n{}: {}", "└─ Driver".with(color).bold(), gpu.driver).as_str());
         }
 
-        str.push_str(format!("\n{}: {}MB",
-                             "RAM".with(color).bold(),
-                             self.ram_total / 1_000_000
+        str.push_str(
+            format!(
+                "\n{}: {}GB",
+                "RAM".with(color).bold(),
+                self.ram_total / 1_000_000_000
+            )
+            .as_str(),
+        );
 
-        ).as_str());
+        str.push_str(
+            format!(
+                "\n{}: {}GB - {:.1}%",
+                "├─ Used".with(color).bold(),
+                self.ram_used / 1_000_000_000,
+                (self.ram_used as f64 / self.ram_total as f64) * 100.0
+            )
+            .as_str(),
+        );
 
-        str.push_str(format!("\n{}: {}MB - {:.1}%",
-                             "├ Used".with(color).bold(),
-                             self.ram_used / 1_000_000,
-                             (self.ram_used as f64 / self.ram_total as f64) * 100.0
-        ).as_str());
+        str.push_str(
+            format!(
+                "\n{}: {}GB",
+                "└─ Swap".with(color).bold(),
+                self.ram_swap / 1_000_000_000
+            )
+            .as_str(),
+        );
 
-        str.push_str(format!("\n{}: {}MB",
-                             "└ Swap".with(color).bold(),
-                             self.ram_swap / 1_000_000
-        ).as_str());
-
-        str.push_str(format!("\n{}",
-                             "Storage".with(color).bold()
-        ).as_str());
+        str.push_str(format!("\n{}", "Storage".with(color).bold()).as_str());
 
         for i in 0..self.storage_drives.len() {
-            let symbol = if i == self.storage_drives.len() - 1 { "└" } else { "├" };
+            let symbol = if i == self.storage_drives.len() - 1 {
+                FIRST_SYMBOL
+            } else {
+                OTHER_SYMBOL
+            };
 
             if let Some(drive) = self.storage_drives.get(i) {
-                str.push_str(format!("\n{} {} {}GB / {}GB - {:.1}%",
-                                     symbol.with(color).bold(),
-                                     drive.drive_path.as_str().with(color).bold(),
-                                     drive.storage_used / 1_000_000_000,
-                                     drive.storage_total / 1_000_000_000,
-                                     (drive.storage_used as f64 / drive.storage_total as f64) * 100.0
-                ).as_str());
+                str.push_str(
+                    format!(
+                        "\n{} {} {}GB / {}GB - {:.1}%",
+                        symbol.with(color).bold(),
+                        drive.drive_path.as_str().with(color).bold(),
+                        drive.storage_used / 1_000_000_000,
+                        drive.storage_total / 1_000_000_000,
+                        (drive.storage_used as f64 / drive.storage_total as f64) * 100.0
+                    )
+                    .as_str(),
+                );
             }
         }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,21 +1,20 @@
-use std::env;
-use std::ops::Add;
-use battery::State;
+use crate::helper::{self};
+use crate::model::{Battery, Dimension, Drive, Gpu, Network, SystemInfo};
 use battery::units::energy::watt_hour;
 use battery::units::Time;
-use sysinfo::{CpuExt, DiskExt, NetworkExt, NetworksExt, System, SystemExt};
+use battery::State;
 use chrono::Local;
 use os_info::Bitness;
+use std::env;
+use sysinfo::{Disks, Networks, System};
 use wgpu::{Backends, InstanceDescriptor};
 use winit::event_loop::EventLoop;
-use crate::helper;
-use crate::model::{Battery, Dimension, Drive, Gpu, Network, SystemInfo};
 
 pub fn get_info() -> SystemInfo {
     let mut sysinfo = System::new_all();
     sysinfo.refresh_all();
     sysinfo.refresh_cpu();
-    std::thread::sleep(System::MINIMUM_CPU_UPDATE_INTERVAL);
+    std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
     sysinfo.refresh_cpu();
 
     SystemInfo {
@@ -23,12 +22,12 @@ pub fn get_info() -> SystemInfo {
         current_directory: get_current_directory(),
         current_path: get_current_path(),
         time: get_time(),
-        os: get_os(&sysinfo),
-        os_version: get_os_version(&sysinfo),
+        os: get_os(),
+        os_version: get_os_version(),
         os_bits: get_os_bits(),
-        host: get_host(&sysinfo),
-        network: get_network(&sysinfo),
-        uptime: get_uptime(&sysinfo),
+        host: get_host(),
+        networks: get_networks(),
+        uptime: get_uptime(),
         screen_res: get_screen_res(),
         batteries: get_battery(),
         cpu_name: get_cpu_name(&sysinfo),
@@ -37,7 +36,7 @@ pub fn get_info() -> SystemInfo {
         cpu_base_frequency: get_cpu_base_frequency(&sysinfo),
         cpu_utilization: get_cpu_utilization(&sysinfo),
         gpus: get_gpus(),
-        storage_drives: get_storage_drives(&sysinfo),
+        storage_drives: get_storage_drives(),
         ram_total: get_ram_total(&sysinfo),
         ram_swap: get_ram_swap(&sysinfo),
         ram_used: get_ram_used(&sysinfo),
@@ -50,30 +49,24 @@ fn get_user() -> String {
 
 fn get_current_directory() -> String {
     match env::current_dir() {
-        Ok(dir) => {
-            match dir.into_os_string().into_string() {
-                Ok(dir_str) => { dir_str }
-                Err(_) => { "/".to_string() }
-            }
-        }
-        Err(_) => { "/".to_string() }
+        Ok(dir) => match dir.into_os_string().into_string() {
+            Ok(dir_str) => dir_str,
+            Err(_) => "/".to_string(),
+        },
+        Err(_) => "/".to_string(),
     }
 }
 
 fn get_current_path() -> String {
     match env::current_dir() {
-        Ok(dir) => {
-            match dir.file_name() {
-                None => { "/".to_string() }
-                Some(path) => {
-                    match path.to_str() {
-                        None => { "/".to_string() }
-                        Some(path_str) => { path_str.to_string() }
-                    }
-                }
-            }
-        }
-        Err(_) => { "/".to_string() }
+        Ok(dir) => match dir.file_name() {
+            None => "/".to_string(),
+            Some(path) => match path.to_str() {
+                None => "/".to_string(),
+                Some(path_str) => path_str.to_string(),
+            },
+        },
+        Err(_) => "/".to_string(),
     }
 }
 
@@ -81,18 +74,17 @@ fn get_time() -> String {
     Local::now().format("%H:%M:%S").to_string()
 }
 
-
-fn get_os(sys: &System) -> String {
-    match sys.name() {
-        None => { "/".to_string() }
-        Some(os_name) => { os_name }
+fn get_os() -> String {
+    match System::name() {
+        None => "/".to_string(),
+        Some(os_name) => os_name,
     }
 }
 
-fn get_os_version(sys: &System) -> String {
-    match sys.os_version() {
-        None => { "".to_string() }
-        Some(os_version) => { os_version }
+fn get_os_version() -> String {
+    match System::os_version() {
+        None => "".to_string(),
+        Some(os_version) => os_version,
     }
 }
 
@@ -100,73 +92,59 @@ fn get_os_bits() -> String {
     let bits = os_info::get().bitness();
 
     match bits {
-        Bitness::Unknown => { "/".to_string() }
-        Bitness::X32 => { bits.to_string() }
-        Bitness::X64 => { bits.to_string() }
-        _ => { "/".to_string() }
+        Bitness::Unknown => "/".to_string(),
+        Bitness::X32 => bits.to_string(),
+        Bitness::X64 => bits.to_string(),
+        _ => "/".to_string(),
     }
 }
 
-fn get_host(sys: &System) -> String {
-    match sys.host_name() {
-        None => { "/".to_string() }
-        Some(host) => { host }
+fn get_host() -> String {
+    match System::host_name() {
+        None => "/".to_string(),
+        Some(host) => host,
     }
 }
 
-fn get_uptime(sys: &System) -> String {
-    let duration = sys.uptime();
+fn get_uptime() -> String {
+    let duration = System::uptime();
     helper::sec_to_h_m_s_str(duration as i64)
 }
 
-fn get_network(sys: &System) -> Network{
-    let mut sorted_networks = sys.networks().iter()
-        .collect::<Vec<_>>();
-    sorted_networks.sort_unstable_by(|a, b| {
-        let a_total = a.1.transmitted().add(a.1.received());
-        let b_total = b.1.transmitted().add(b.1.received());
-        let comparison = b_total.cmp(&a_total);
-        if comparison == std::cmp::Ordering::Equal {
-            a.0.len().cmp(&b.0.len())
-        } else {
-            comparison
+fn get_networks() -> Vec<Network> {
+    let mut vec: Vec<Network> = Vec::new();
+
+    let networks = Networks::new_with_refreshed_list();
+
+    for (interface_name, data) in &networks {
+        if data.total_received() > 0 && data.total_transmitted() > 0 {
+            vec.push(Network {
+                network_name: interface_name.to_string(),
+                network_up: data.total_transmitted(),
+                network_down: data.total_received(),
+            })
         }
-    });
-
-    let network = sorted_networks.first().unwrap().to_owned();
-
-    Network {
-        network_name: network.0.to_string(),
-        network_up: network.1.total_transmitted(),
-        network_down: network.1.total_received()
     }
 
+    vec
 }
 
 fn get_screen_res() -> Dimension {
     match EventLoop::new() {
-        Ok(event) => {
-            match event.primary_monitor() {
-                None => {
-                    Dimension {
-                        width: 0,
-                        height: 0,
-                    }
-                }
-                Some(monitor) => {
-                    Dimension {
-                        width: monitor.size().width as i32,
-                        height: monitor.size().height as i32,
-                    }
-                }
-            }
-        }
-        Err(_) => {
-            Dimension {
+        Ok(event) => match event.primary_monitor() {
+            None => Dimension {
                 width: 0,
                 height: 0,
-            }
-        }
+            },
+            Some(monitor) => Dimension {
+                width: monitor.size().width as i32,
+                height: monitor.size().height as i32,
+            },
+        },
+        Err(_) => Dimension {
+            width: 0,
+            height: 0,
+        },
     }
 }
 
@@ -188,7 +166,7 @@ fn get_battery() -> Option<Vec<Battery>> {
                     current_load: battery.energy().get::<watt_hour>() as u64,
                     max_load: battery.energy_full().get::<watt_hour>() as u64,
                     current_state: battery.state(),
-                    until_empty_or_full: time
+                    until_empty_or_full: time,
                 })
             }
         }
@@ -206,16 +184,20 @@ fn get_cpu_name(sys: &System) -> String {
 }
 
 fn get_cpu_base_frequency(sys: &System) -> u64 {
-    match sys.cpus().iter().max_by(|a, b| a.frequency().cmp(&b.frequency())) {
-        None => { 0 }
-        Some(cpu) => { cpu.frequency() - 1 }
+    match sys
+        .cpus()
+        .iter()
+        .max_by(|a, b| a.frequency().cmp(&b.frequency()))
+    {
+        None => 0,
+        Some(cpu) => cpu.frequency() - 1,
     }
 }
 
 fn get_cpu_cores(sys: &System) -> u32 {
     match sys.physical_core_count() {
-        None => { 0 }
-        Some(cores) => { cores as u32 }
+        None => 0,
+        Some(cores) => cores as u32,
     }
 }
 
@@ -238,28 +220,28 @@ fn get_gpus() -> Vec<Gpu> {
         vec.push(Gpu {
             name: info.name,
             gpu_type: info.device_type,
-            driver: info.driver_info
+            driver: info.driver_info,
         });
     }
 
     vec
 }
 
-fn get_storage_drives(sys: &System) -> Vec<Drive> {
+fn get_storage_drives() -> Vec<Drive> {
     let mut vec: Vec<Drive> = Vec::new();
 
-    let disks = sys.disks();
+    let disks = Disks::new_with_refreshed_list();
 
-    for disk in disks {
+    for disk in &disks {
         vec.push(Drive {
             drive_path: match disk.mount_point().to_str() {
-                None => { "/".to_string() }
-                Some(disk_str) => { disk_str.to_string() }
+                None => "/".to_string(),
+                Some(disk_str) => disk_str.to_string(),
             },
             storage_total: disk.total_space(),
             storage_used: disk.total_space() - disk.available_space(),
         });
-    };
+    }
 
     vec
 }
@@ -275,4 +257,3 @@ fn get_ram_used(sys: &System) -> u64 {
 fn get_ram_swap(sys: &System) -> u64 {
     sys.total_swap()
 }
-


### PR DESCRIPTION
    add support for multiple network interfaces
    
    this commit does the following things:
    - add support for multiple network interfaces
    - updates sysinfo to v0.33.11
    - used GB for RAM output (earlier it was MB)
    - for tree symbols, I've defined two const and used them at few places.
    
    Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>


- network interfaces where there are zero network activity are ignored in the output.  
- The diff looks long because I'm using [helix](https://github.com/helix-editor/helix) and it did some code formatting which I think is more readable so I proceeded with the same.

<details><summary> screenshot with more than one network interface </summary>
<p>

![image](https://github.com/GHaxZ/fetchy/assets/81210977/f37419d2-49c3-48af-9356-96f73dd980be)


</p>
</details> 